### PR TITLE
feat(cmd): add possibility to add a remote repository

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -365,6 +365,7 @@ version = "0.0.1-alpha.1"
 dependencies = [
  "async-trait",
  "clap",
+ "reckless_github",
  "reckless_lib",
  "tokio",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,26 +59,24 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "3.2.19"
+version = "4.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68d43934757334b5c0519ff882e1ab9647ac0258b47c24c4f490d78e42697fd5"
+checksum = "2148adefda54e14492fb9bddcc600b4344c5d1a3123bd666dcb939c6f0e0e57e"
 dependencies = [
  "atty",
  "bitflags",
  "clap_derive",
  "clap_lex",
- "indexmap",
  "once_cell",
  "strsim",
  "termcolor",
- "textwrap",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "3.2.18"
+version = "4.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
+checksum = "0177313f9f02afc995627906bbd8967e2be069f5261954222dac78290c2b9014"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -89,9 +87,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.2.4"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
 dependencies = [
  "os_str_bytes",
 ]
@@ -121,12 +119,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-
-[[package]]
 name = "heck"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -149,16 +141,6 @@ checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
-]
-
-[[package]]
-name = "indexmap"
-version = "1.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
-dependencies = [
- "autocfg",
- "hashbrown",
 ]
 
 [[package]]
@@ -470,12 +452,6 @@ checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
 ]
-
-[[package]]
-name = "textwrap"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "tinyvec"

--- a/reckless_cmd/Cargo.toml
+++ b/reckless_cmd/Cargo.toml
@@ -6,6 +6,6 @@ edition = "2021"
 
 [dependencies]
 tokio = { version = "1", features = ["full"] }
-clap = { version = "3.2.19", features = ["derive"] }
+clap = { version = "4.0.26", features = ["derive"] }
 async-trait = "0.1.57"
 reckless_lib = { path = "../reckless_lib" }

--- a/reckless_cmd/Cargo.toml
+++ b/reckless_cmd/Cargo.toml
@@ -9,3 +9,4 @@ tokio = { version = "1", features = ["full"] }
 clap = { version = "4.0.26", features = ["derive"] }
 async-trait = "0.1.57"
 reckless_lib = { path = "../reckless_lib" }
+reckless_github = { path = "../reckless_github"  }

--- a/reckless_cmd/src/main.rs
+++ b/reckless_cmd/src/main.rs
@@ -2,7 +2,10 @@ mod reckless;
 
 use crate::reckless::cmd::RecklessArgs;
 use clap::Parser;
-use reckless::{cmd::RecklessCommand, RecklessManager};
+use reckless::{
+    cmd::{RecklessCommand, RemoteAction},
+    RecklessManager,
+};
 use reckless_lib::{errors::RecklessError, plugin_manager::PluginManager};
 
 #[tokio::main]
@@ -14,6 +17,13 @@ async fn main() -> Result<(), RecklessError> {
         RecklessCommand::Remove => todo!(),
         RecklessCommand::List => reckless.list().await,
         RecklessCommand::Upgrade => reckless.upgrade(&[""]).await,
+        RecklessCommand::Remote { action } => {
+            if let RemoteAction::Add { name, url } = action {
+                reckless.add_remote(name.as_str(), url.as_str()).await
+            } else {
+                Err(RecklessError::new(1, "command not supported"))
+            }
+        }
     };
 
     if let Err(err) = result {

--- a/reckless_cmd/src/reckless/cmd.rs
+++ b/reckless_cmd/src/reckless/cmd.rs
@@ -29,4 +29,16 @@ pub enum RecklessCommand {
     /// Remove a plugin installed in cln.
     #[clap(arg_required_else_help = true)]
     Remove,
+    /// Manage Repository subcommand
+    #[clap(arg_required_else_help = true)]
+    Remote {
+        #[clap(subcommand)]
+        action: RemoteAction,
+    },
+}
+
+#[derive(Debug, Subcommand)]
+pub enum RemoteAction {
+    Add { name: String, url: String },
+    Remove { name: String },
 }

--- a/reckless_cmd/src/reckless/mod.rs
+++ b/reckless_cmd/src/reckless/mod.rs
@@ -52,4 +52,11 @@ impl PluginManager for RecklessManager {
     async fn upgrade(&mut self, plugins: &[&str]) -> Result<(), RecklessError> {
         Ok(())
     }
+
+    async fn add_remote(&mut self, name: &str, url: &str) -> Result<(), RecklessError> {
+        // 1. create the repository
+        // 2. init the repository
+        // 3. if all is ok store the repository in the plugin manager
+        Ok(())
+    }
 }

--- a/reckless_github/src/lib.rs
+++ b/reckless_github/src/lib.rs
@@ -16,7 +16,7 @@ mod tests {
         let url = "https://github.com/lightningd/plugins";
         let repo = Github::new(name, url);
         let repo = repo.init().await;
-
+        assert!(repo.is_ok());
         assert_eq!(Path::new(&(get_dir_path_from_url(url))).exists(), true);
     }
 }

--- a/reckless_lib/src/plugin_manager.rs
+++ b/reckless_lib/src/plugin_manager.rs
@@ -19,4 +19,7 @@ pub trait PluginManager {
 
     /// upgrade a sequence of plugin managed by the plugin manager.
     async fn upgrade(&mut self, plugins: &[&str]) -> Result<(), RecklessError>;
+
+    /// add the remote repository to the plugin manager.
+    async fn add_remote(&mut self, name: &str, url: &str) -> Result<(), RecklessError>;
 }


### PR DESCRIPTION
This is my work to add an API for the cmd in order to support the feature added by this PR https://github.com/cln-reckless/reckless.rs/pull/4

I think that the remote need an additional sub command

Signed-off-by: Vincenzo Palazzo <vincenzopalazzodev@gmail.com>