### PR TITLE
log: add logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4f55bd91a0978cbfd91c457a164bab8b4001c833b7f323132c0a4e1922dd44e"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -95,6 +104,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_logger"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a12e6657c4c97ebab115a42dcee77225f7f482cdd841cf7088c657a42e9e00e7"
+dependencies = [
+ "atty",
+ "humantime",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
 name = "form_urlencoded"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -132,6 +154,12 @@ checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "idna"
@@ -365,6 +393,8 @@ version = "0.0.1-alpha.1"
 dependencies = [
  "async-trait",
  "clap",
+ "env_logger",
+ "log",
  "reckless_github",
  "reckless_lib",
  "tokio",
@@ -375,7 +405,9 @@ name = "reckless_github"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "env_logger",
  "git2",
+ "log",
  "reckless_lib",
  "tokio",
 ]
@@ -385,7 +417,9 @@ name = "reckless_lib"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "env_logger",
  "git2",
+ "log",
 ]
 
 [[package]]
@@ -396,6 +430,23 @@ checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
  "bitflags",
 ]
+
+[[package]]
+name = "regex"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e076559ef8e241f2ae3479e36f97bd5741c0330689e217ad51ce2c76808b868a"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
 name = "scopeguard"

--- a/reckless_cmd/Cargo.toml
+++ b/reckless_cmd/Cargo.toml
@@ -10,3 +10,5 @@ clap = { version = "4.0.26", features = ["derive"] }
 async-trait = "0.1.57"
 reckless_lib = { path = "../reckless_lib" }
 reckless_github = { path = "../reckless_github"  }
+log = "0.4.17"
+env_logger = "0.9.3"

--- a/reckless_cmd/src/main.rs
+++ b/reckless_cmd/src/main.rs
@@ -10,6 +10,7 @@ use reckless_lib::{errors::RecklessError, plugin_manager::PluginManager};
 
 #[tokio::main]
 async fn main() -> Result<(), RecklessError> {
+    env_logger::init();
     let args = RecklessArgs::parse();
     let mut reckless = RecklessManager::new(&args).await?;
     let result = match args.command {
@@ -21,7 +22,7 @@ async fn main() -> Result<(), RecklessError> {
             if let RemoteAction::Add { name, url } = action {
                 reckless.add_remote(name.as_str(), url.as_str()).await
             } else {
-                Err(RecklessError::new(1, "command not supported"))
+                Err(RecklessError::new(1, "unsupported command"))
             }
         }
     };

--- a/reckless_cmd/src/reckless/mod.rs
+++ b/reckless_cmd/src/reckless/mod.rs
@@ -1,4 +1,5 @@
 //! Reckless mod implementation
+use log::debug;
 use std::vec::Vec;
 
 use async_trait::async_trait;
@@ -40,10 +41,13 @@ impl RecklessManager {
 #[async_trait]
 impl PluginManager for RecklessManager {
     async fn configure(&mut self) -> Result<(), RecklessError> {
+        debug!("PLUGIN CONFIGURED");
         Ok(())
     }
 
     async fn install(&mut self, plugins: &[&str]) -> Result<(), RecklessError> {
+        // FIXME: Fix debug message with the list of plugins to be installed
+        debug!("INSTALLING PLUGINS");
         Ok(())
     }
 
@@ -52,13 +56,17 @@ impl PluginManager for RecklessManager {
     }
 
     async fn upgrade(&mut self, plugins: &[&str]) -> Result<(), RecklessError> {
+        // FIXME: Fix debug message with the list of plugins to be upgraded
+        debug!("UPGRADING PLUGINS");
         Ok(())
     }
 
     async fn add_remote(&mut self, name: &str, url: &str) -> Result<(), RecklessError> {
+        debug!("REMOTE ADDING: {} {}", name, url);
         let repo = Github::new(name, url);
         repo.init().await?;
         self.repos.push(Box::new(repo));
+        debug!("REMOTE ADDED: {} {}", name, url);
         Ok(())
     }
 }

--- a/reckless_github/Cargo.toml
+++ b/reckless_github/Cargo.toml
@@ -8,3 +8,5 @@ reckless_lib = { path = "../reckless_lib" }
 async-trait = "0.1.57"
 tokio = { version = "1.21.2", features = ["full"] }
 git2 = "0.15.0"
+log = "0.4.17"
+env_logger = "0.9.3"

--- a/reckless_github/src/lib.rs
+++ b/reckless_github/src/lib.rs
@@ -4,14 +4,25 @@ pub mod repository;
 
 #[cfg(test)]
 mod tests {
-    use std::path::Path;
+    use std::{path::Path, sync::Once};
 
-    use reckless_lib::{repository::Repository, utils::get_dir_path_from_url};
+    use reckless_lib::repository::Repository;
+    use reckless_lib::utils::get_dir_path_from_url;
 
     use crate::repository::Github;
 
+    static INIT: Once = Once::new();
+
+    fn init() {
+        // ignore error
+        INIT.call_once(|| {
+            env_logger::init();
+        });
+    }
+
     #[tokio::test]
     async fn repository_is_initialized_ok() {
+        init();
         let name = "hello";
         let url = "https://github.com/lightningd/plugins";
         let repo = Github::new(name, url);

--- a/reckless_github/src/repository.rs
+++ b/reckless_github/src/repository.rs
@@ -1,9 +1,11 @@
 use async_trait::async_trait;
 use git2;
+use log::debug;
 use reckless_lib::errors::RecklessError;
 use reckless_lib::plugin::Plugin;
 use reckless_lib::repository::Repository;
-use reckless_lib::utils::{clone_recursive_fix, get_dir_path_from_url};
+use reckless_lib::utils::clone_recursive_fix;
+use reckless_lib::utils::get_dir_path_from_url;
 
 pub struct Github {
     /// the url of the repository to be able
@@ -21,6 +23,7 @@ impl Github {
     /// Create a new instance of the Repository
     /// with a name and a url
     pub fn new(name: &str, url: &str) -> Self {
+        debug!("ADDING REPOSITORY: {name} {url}");
         Github {
             name: name.to_owned(),
             url: url.to_owned(),
@@ -37,6 +40,12 @@ impl Repository for Github {
     /// Where to store the index is an implementation
     /// details.
     async fn init(&self) -> Result<(), RecklessError> {
+        debug!(
+            "INITIALIZING REPOSITORY: {} {} > {}",
+            self.name,
+            self.url,
+            get_dir_path_from_url(&self.url)
+        );
         let res = git2::Repository::clone(&self.url, get_dir_path_from_url(&self.url));
         match res {
             Ok(repo) => clone_recursive_fix(repo, &self.url),

--- a/reckless_lib/Cargo.toml
+++ b/reckless_lib/Cargo.toml
@@ -6,3 +6,5 @@ edition = "2021"
 [dependencies]
 async-trait = "0.1.57"
 git2 = "0.15.0"
+log = "0.4.17"
+env_logger = "0.9.3"

--- a/reckless_lib/src/errors.rs
+++ b/reckless_lib/src/errors.rs
@@ -1,3 +1,4 @@
+use log::error;
 use std::fmt;
 
 /// Specific repository error.
@@ -11,6 +12,7 @@ impl RecklessError {
     /// Build a new error message with a specific code
     /// and a specific message.
     pub fn new(code: u64, msg: &str) -> Self {
+        error!("ERROR #{}: {}", code, msg);
         RecklessError {
             code,
             msg: msg.to_string(),


### PR DESCRIPTION
This PR will add logging support for reckless!
Fixes #5 

```bash
     Running `target/debug/reckless_cmd remote add plugins 'https://github.com/lightningd/plugins'`
[2022-11-19T14:37:29Z DEBUG reckless_cmd::reckless] REMOTE ADDING: plugins https://github.com/lightningd/plugins
[2022-11-19T14:37:29Z DEBUG reckless_github::repository] ADDING REPOSITORY: plugins https://github.com/lightningd/plugins
[2022-11-19T14:37:29Z DEBUG reckless_github::repository] INITIALIZING REPOSITORY: plugins https://github.com/lightningd/plugins > /home/swapnil/.reckless/lightningd/plugins
[2022-11-19T14:37:30Z DEBUG reckless_lib::utils] SUBMODULE COUNT: 14
[2022-11-19T14:37:30Z DEBUG reckless_lib::utils] URL 1: https://github.com/clightning4j/btcli4j.git
[2022-11-19T14:37:32Z DEBUG reckless_lib::utils] ADDED https://github.com/clightning4j/btcli4j.git
[2022-11-19T14:37:32Z DEBUG reckless_lib::utils] URL 2: https://github.com/giovannizotta/circular.git
[2022-11-19T14:37:35Z DEBUG reckless_lib::utils] ADDED https://github.com/giovannizotta/circular.git
[2022-11-19T14:37:35Z DEBUG reckless_lib::utils] URL 3: https://github.com/0xB10C/c-lightning-plugin-csvexportpays.git
[2022-11-19T14:37:36Z DEBUG reckless_lib::utils] ADDED https://github.com/0xB10C/c-lightning-plugin-csvexportpays.git
[2022-11-19T14:37:36Z DEBUG reckless_lib::utils] URL 4: https://github.com/LNOpenMetrics/go-lnmetrics.reporter.git
[2022-11-19T14:37:45Z DEBUG reckless_lib::utils] ADDED https://github.com/LNOpenMetrics/go-lnmetrics.reporter.git
[2022-11-19T14:37:45Z DEBUG reckless_lib::utils] URL 5: https://github.com/nettijoe96/c-lightning-graphql.git
[2022-11-19T14:37:46Z DEBUG reckless_lib::utils] ADDED https://github.com/nettijoe96/c-lightning-graphql.git
[2022-11-19T14:37:46Z DEBUG reckless_lib::utils] URL 6: https://github.com/nettijoe96/jwt-factory.git
[2022-11-19T14:37:47Z DEBUG reckless_lib::utils] ADDED https://github.com/nettijoe96/jwt-factory.git
[2022-11-19T14:37:47Z DEBUG reckless_lib::utils] URL 7: https://github.com/darosior/pylightning-qt.git
[2022-11-19T14:37:48Z DEBUG reckless_lib::utils] ADDED https://github.com/darosior/pylightning-qt.git
[2022-11-19T14:37:48Z DEBUG reckless_lib::utils] URL 8: https://github.com/fiatjaf/poncho
[2022-11-19T14:37:49Z DEBUG reckless_lib::utils] ADDED https://github.com/fiatjaf/poncho
[2022-11-19T14:37:49Z DEBUG reckless_lib::utils] URL 9: https://github.com/talaia-labs/python-teos
[2022-11-19T14:37:51Z DEBUG reckless_lib::utils] ADDED https://github.com/talaia-labs/python-teos
[2022-11-19T14:37:51Z DEBUG reckless_lib::utils] URL 10: https://github.com/talaia-labs/rust-teos.git
[2022-11-19T14:37:52Z DEBUG reckless_lib::utils] ADDED https://github.com/talaia-labs/rust-teos.git
[2022-11-19T14:37:52Z DEBUG reckless_lib::utils] URL 11: https://github.com/niftynei/sitzprobe.git
[2022-11-19T14:37:53Z DEBUG reckless_lib::utils] ADDED https://github.com/niftynei/sitzprobe.git
[2022-11-19T14:37:53Z DEBUG reckless_lib::utils] URL 12: https://github.com/fiatjaf/sparko.git
[2022-11-19T14:37:54Z DEBUG reckless_lib::utils] ADDED https://github.com/fiatjaf/sparko.git
[2022-11-19T14:37:54Z DEBUG reckless_lib::utils] URL 13: https://github.com/fiatjaf/trustedcoin.git
[2022-11-19T14:37:55Z DEBUG reckless_lib::utils] ADDED https://github.com/fiatjaf/trustedcoin.git
[2022-11-19T14:37:55Z DEBUG reckless_lib::utils] URL 14: https://github.com/fiatjaf/lightningd-webhook.git
[2022-11-19T14:37:55Z DEBUG reckless_lib::utils] ADDED https://github.com/fiatjaf/lightningd-webhook.git
[2022-11-19T14:37:55Z DEBUG reckless_cmd::reckless] REMOTE ADDED: plugins https://github.com/lightningd/plugins
```