### PR TITLE
url: move remote repo to user defined dir

### DIFF
--- a/reckless_cmd/src/reckless/mod.rs
+++ b/reckless_cmd/src/reckless/mod.rs
@@ -63,7 +63,7 @@ impl PluginManager for RecklessManager {
     }
 
     async fn add_remote(&mut self, name: &str, url: &str) -> Result<(), RecklessError> {
-        let url = URL::new(url);
+        let url = URL::new(url, Some(name));
         debug!("REMOTE ADDING: {} {}", name, &url.url_string);
         let mut repo = Github::new(name, &url);
         repo.init().await?;

--- a/reckless_github/src/lib.rs
+++ b/reckless_github/src/lib.rs
@@ -6,7 +6,6 @@ pub mod repository;
 mod tests {
     use std::{path::Path, sync::Once};
 
-    use log::debug;
     use reckless_lib::repository::Repository;
     use reckless_lib::url::URL;
 
@@ -25,7 +24,10 @@ mod tests {
     async fn repository_is_initialized_ok() {
         init();
         let name = "hello";
-        let url = URL::new("https://github.com/lightningd/plugins");
+        let url = URL::new(
+            "https://github.com/lightningd/plugins",
+            Some("lightningd_plugins"),
+        );
         let mut repo = Github::new(name, &url);
         let repo = repo.init().await;
         assert!(repo.is_ok());


### PR DESCRIPTION
This PR allows cloning remote repo into user defined paths.
Earlier, adding remote repo would result in paths such as `{HOME}/.reckless/repositories/username/repo` which would disregard the `name` argument provided by the user.
Now, adding remote repo would result in path `{HOME}/.reckless/repositories/name/`.