### PR TITLE
feat(reckless): support install command 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -452,6 +452,7 @@ dependencies = [
  "glob",
  "log",
  "serde",
+ "tokio",
 ]
 
 [[package]]
@@ -593,9 +594,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.21.2"
+version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9e03c497dc955702ba729190dc4aac6f2a0ce97f913e5b1b5912fc5039d9099"
+checksum = "d76ce4a75fb488c605c54bf610f221cea8b0dafb53333c1a67e8ee199dcd2ae3"
 dependencies = [
  "autocfg",
  "bytes",

--- a/reckless_cmd/Cargo.toml
+++ b/reckless_cmd/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 
 [dependencies]
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "1.22.0", features = ["full"] }
 clap = { version = "4.0.26", features = ["derive"] }
 async-trait = "0.1.57"
 reckless_lib = { path = "../reckless_lib" }

--- a/reckless_cmd/src/main.rs
+++ b/reckless_cmd/src/main.rs
@@ -1,5 +1,7 @@
 mod reckless;
 
+use std::collections::HashSet;
+
 use crate::reckless::cmd::RecklessArgs;
 use clap::Parser;
 use reckless::cmd::RecklessCommand;
@@ -15,7 +17,13 @@ async fn main() -> Result<(), RecklessError> {
     let args = RecklessArgs::parse();
     let mut reckless = RecklessManager::new(&args).await?;
     let result = match args.command {
-        RecklessCommand::Install { plugin } => reckless.install(&plugin).await,
+        RecklessCommand::Install { plugin } => {
+            let mut unique_plugin: HashSet<String> = HashSet::new();
+            plugin
+                .iter()
+                .map(|plugin| unique_plugin.insert(plugin.to_owned()));
+            reckless.install(&unique_plugin).await
+        }
         RecklessCommand::Remove => todo!(),
         RecklessCommand::List => reckless.list().await,
         RecklessCommand::Upgrade => reckless.upgrade(&[""]).await,

--- a/reckless_cmd/src/main.rs
+++ b/reckless_cmd/src/main.rs
@@ -15,7 +15,7 @@ async fn main() -> Result<(), RecklessError> {
     let args = RecklessArgs::parse();
     let mut reckless = RecklessManager::new(&args).await?;
     let result = match args.command {
-        RecklessCommand::Install => reckless.install(&[""]).await,
+        RecklessCommand::Install { plugin } => reckless.install(&plugin).await,
         RecklessCommand::Remove => todo!(),
         RecklessCommand::List => reckless.list().await,
         RecklessCommand::Upgrade => reckless.upgrade(&[""]).await,

--- a/reckless_cmd/src/reckless/cmd.rs
+++ b/reckless_cmd/src/reckless/cmd.rs
@@ -19,7 +19,7 @@ pub struct RecklessArgs {
 pub enum RecklessCommand {
     /// Install a single or a list of plugins.
     #[clap(arg_required_else_help = true)]
-    Install,
+    Install { plugin: Vec<String> },
     /// upgrade a single or a list of plugins.
     #[clap(arg_required_else_help = true)]
     Upgrade,

--- a/reckless_cmd/src/reckless/mod.rs
+++ b/reckless_cmd/src/reckless/mod.rs
@@ -17,7 +17,9 @@ mod config;
 
 pub struct RecklessManager {
     config: config::RecklessConf,
-    repos: Vec<Box<dyn Repository>>,
+    /// List of repositories
+    repos: Vec<Box<Github>>,
+    /// List of plugins installed
     plugins: Vec<String>,
 }
 
@@ -46,9 +48,21 @@ impl PluginManager for RecklessManager {
         Ok(())
     }
 
-    async fn install(&mut self, plugins: &[&str]) -> Result<(), RecklessError> {
-        // FIXME: Fix debug message with the list of plugins to be installed
-        debug!("installing plugins");
+    async fn install(&mut self, plugins: &Vec<String>) -> Result<(), RecklessError> {
+        debug!("installing plugins {:?}", plugins);
+        for plugin_to_be_installed in plugins {
+            for repo in &self.repos {
+                for plugin_list in repo.list().await {
+                    for mut plugin in plugin_list {
+                        if plugin_to_be_installed == &plugin.name() {
+                            // FIXME: This path needs to be added to config
+                            let path = plugin.configure().await.unwrap();
+                            debug!("{path}");
+                        }
+                    }
+                }
+            }
+        }
         Ok(())
     }
 

--- a/reckless_github/Cargo.toml
+++ b/reckless_github/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 reckless_lib = { path = "../reckless_lib" }
 async-trait = "0.1.57"
-tokio = { version = "1.21.2", features = ["full"] }
+tokio = { version = "1.22.0", features = ["full"] }
 git2 = "0.15.0"
 log = "0.4.17"
 env_logger = "0.9.3"

--- a/reckless_github/src/repository.rs
+++ b/reckless_github/src/repository.rs
@@ -156,6 +156,6 @@ impl Repository for Github {
     /// M.B: in the future we want also list all the plugin installed
     /// inside the repository.
     async fn list(&self) -> Result<Vec<Plugin>, RecklessError> {
-        Ok(vec![])
+        Ok(self.plugins.clone())
     }
 }

--- a/reckless_github/src/repository.rs
+++ b/reckless_github/src/repository.rs
@@ -158,4 +158,14 @@ impl Repository for Github {
     async fn list(&self) -> Result<Vec<Plugin>, RecklessError> {
         Ok(self.plugins.clone())
     }
+
+    /// search inside the repository a plugin by name.
+    fn get_plugin_by_name(&self, name: &str) -> Option<Plugin> {
+        for plugin in &self.plugins {
+            if plugin.name() == name {
+                return Some(plugin.to_owned());
+            }
+        }
+        None
+    }
 }

--- a/reckless_lib/Cargo.toml
+++ b/reckless_lib/Cargo.toml
@@ -10,3 +10,4 @@ git2 = "0.15.0"
 log = "0.4.17"
 env_logger = "0.9.3"
 glob = "0.3.0"
+tokio = { version = "1.22.0", features = ["process"] }

--- a/reckless_lib/src/plugin_conf.rs
+++ b/reckless_lib/src/plugin_conf.rs
@@ -1,12 +1,14 @@
 //! FIXME : put some docs here!
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
+
 pub struct Conf {
     pub plugin: Plugin,
 }
 
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
+
 pub struct Plugin {
     pub name: String,
     pub version: String,
@@ -20,4 +22,10 @@ pub struct Plugin {
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct Deprecaterd {
     pub reason: String,
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_remote() {}
 }

--- a/reckless_lib/src/plugin_manager.rs
+++ b/reckless_lib/src/plugin_manager.rs
@@ -12,7 +12,7 @@ pub trait PluginManager {
 
     /// install a sequence of plugin or return an error if somethings happens.
     // FIXME: what happens if only one plugin fails?
-    async fn install(&mut self, plugins: &[&str]) -> Result<(), RecklessError>;
+    async fn install(&mut self, plugins: &Vec<String>) -> Result<(), RecklessError>;
 
     /// return the list of pluing manager by the plugin manager.
     async fn list(&mut self) -> Result<(), RecklessError>;

--- a/reckless_lib/src/plugin_manager.rs
+++ b/reckless_lib/src/plugin_manager.rs
@@ -1,5 +1,6 @@
 //! Plugin manager module definition.
 use async_trait::async_trait;
+use std::collections::HashSet;
 
 use crate::errors::RecklessError;
 
@@ -12,7 +13,7 @@ pub trait PluginManager {
 
     /// install a sequence of plugin or return an error if somethings happens.
     // FIXME: what happens if only one plugin fails?
-    async fn install(&mut self, plugins: &Vec<String>) -> Result<(), RecklessError>;
+    async fn install(&mut self, plugins: &HashSet<String>) -> Result<(), RecklessError>;
 
     /// return the list of pluing manager by the plugin manager.
     async fn list(&mut self) -> Result<(), RecklessError>;

--- a/reckless_lib/src/repository.rs
+++ b/reckless_lib/src/repository.rs
@@ -13,6 +13,9 @@ pub trait Repository {
     /// This should work like a `git fetch`.
     async fn init(&mut self) -> Result<(), RecklessError>;
 
+    /// search inside the repository a plugin by name.
+    fn get_plugin_by_name(&self, name: &str) -> Option<Plugin>;
+
     /// return the list of plugin that are register contained inside the repository.
     async fn list(&self) -> Result<Vec<Plugin>, RecklessError>;
 }


### PR DESCRIPTION
This PR is a clean-up of the
https://github.com/cln-reckless/reckless.rs/pull/14
that clean up the install script and configure and
fix without breaking the architecture of the plugin manager
the `Send` and `Sync` tokio requirements.

Signed-off-by: Vincenzo Palazzo <vincenzopalazzodev@gmail.com>