### PR TITLE
feat(storage): add a storage crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,6 +104,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "coffe_storage"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "reckless_lib",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "env_logger"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -421,10 +431,12 @@ version = "0.0.1-alpha.1"
 dependencies = [
  "async-trait",
  "clap",
+ "coffe_storage",
  "env_logger",
  "log",
  "reckless_github",
  "reckless_lib",
+ "serde",
  "tokio",
 ]
 
@@ -511,6 +523,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "020ff22c755c2ed3f8cf162dbb41a7268d934702f3ed3631656ea597e08fc3db"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,5 +3,6 @@ members = [
         "reckless_lib",
         "reckless_cmd",
         "reckless_github",
+        "storage",
 ]
 resolver = "2"

--- a/reckless_cmd/Cargo.toml
+++ b/reckless_cmd/Cargo.toml
@@ -12,3 +12,5 @@ reckless_lib = { path = "../reckless_lib" }
 reckless_github = { path = "../reckless_github"  }
 log = "0.4.17"
 env_logger = "0.9.3"
+coffe_storage = { path = "../storage"  }
+serde = { version = "1.0", features = ["derive"] }

--- a/reckless_cmd/src/reckless/cmd.rs
+++ b/reckless_cmd/src/reckless/cmd.rs
@@ -3,7 +3,7 @@ use clap::{Parser, Subcommand};
 
 /// Reckless main command line definition for the command line tools.
 #[derive(Debug, Parser)]
-#[clap(name = "rkl")]
+#[clap(name = "coffe")]
 #[clap(about = "A reckless plugin manager for core lightning", long_about = None)]
 pub struct RecklessArgs {
     #[clap(subcommand)]

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "coffe_storage"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+async-trait = "^0.1.57"
+reckless_lib = { path = "../reckless_lib" }

--- a/storage/src/file.rs
+++ b/storage/src/file.rs
@@ -1,0 +1,32 @@
+//! file is a module to store a simple
+//! JSON file on the disk with a full
+//! dump of the plugin manager status.
+//!
+//! This will work for the initial version
+//! of it, but maybe in the future it is needed
+//! a more smart version of storage manager
+use crate::storage::StorageManager;
+use async_trait::async_trait;
+use reckless_lib::{errors::RecklessError, plugin_manager::PluginManager};
+use serde::{Deserialize, Serialize};
+
+pub struct FileStorage {}
+
+#[async_trait]
+impl<T> StorageManager<T> for FileStorage {
+    type Err = RecklessError;
+
+    async fn load(&self, to_load: &mut T) -> Result<(), Self::Err>
+    where
+        T: Deserialize<'static> + Send + Sync,
+    {
+        todo!()
+    }
+
+    async fn store(&self, to_store: &T) -> Result<(), Self::Err>
+    where
+        T: Serialize + Send + Sync,
+    {
+        todo!()
+    }
+}

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -1,0 +1,6 @@
+//! coffe_storage crate define the different way to
+//! define a storage for the plugin manager in
+//! order to define the interface to manage the
+//! information to store on disk.
+pub mod file;
+pub mod storage;

--- a/storage/src/storage.rs
+++ b/storage/src/storage.rs
@@ -1,0 +1,23 @@
+//! storage define the interface of the storage
+//! manager that need to be implemented in other
+//! to work with the the plugin manager
+//! architecture.
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+
+#[async_trait]
+pub trait StorageManager<T> {
+    type Err;
+
+    /// async call to persist the information
+    /// on disk.
+    async fn store(&self, to_store: &T) -> Result<(), Self::Err>
+    where
+        T: Serialize + Send + Sync;
+
+    /// async call to load the data that was made persistent
+    /// from the previous `store` call.
+    async fn load(&self, to_load: &mut T) -> Result<(), Self::Err>
+    where
+        T: Deserialize<'static> + Send + Sync;
+}


### PR DESCRIPTION
This introduces a storage crate that allows implementing a storage manager that allows implementing the kind of storage that can store the plugin manager information on the disk.

Signed-off-by: Vincenzo Palazzo <vincenzopalazzodev@gmail.com>