### PR TITLE
fix(github): fix the plugin identification

### DIFF
--- a/reckless_github/Cargo.toml
+++ b/reckless_github/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 reckless_lib = { path = "../reckless_lib" }
 async-trait = "0.1.57"
-tokio = { version = "1.22.0", features = ["full"] }
+tokio = { version = "1.22.0", features = ["fs"] }
 git2 = "0.15.0"
 log = "0.4.17"
 env_logger = "0.9.3"

--- a/reckless_lib/src/plugin.rs
+++ b/reckless_lib/src/plugin.rs
@@ -5,7 +5,7 @@ use std::fmt;
 use tokio::process::Command;
 
 /// Plugin language definition
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum PluginLang {
     Python,
     Go,


### PR DESCRIPTION
This will write in a known bug-free plugin identification because the previous implementation was a little bit messy and untested.

Each time that a language was found will create a new plugin, this is wrong because it is just a guess that we can do this way, and we can risk trying to be smart but we are really dumb like in the case of javascript that it can contains also the typescript configuration and in this case, we do not know what happens.

The work is not finished because the configuration should override the guess about the language, because the conf information is more important for the plugin manager.

Signed-off-by: Vincenzo Palazzo <vincenzopalazzodev@gmail.com>